### PR TITLE
wrong version in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The package can be installed by adding `picam` to your list of dependencies in `
 
 ```elixir
 def deps do
-  [{:picam, "~> 0.4.0"}]
+  [{:picam, "~> 0.3.0"}]
 end
 ```
 


### PR DESCRIPTION
The README states version`0.4.0` but the latest hex version is `0.3.0`.