### PR TITLE
Remove potentially catastrophic rm -fr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,6 @@ $(PREFIX)/%: assets/%
 	cp $< $@
 
 clean:
-	rm -rf $(PREFIX)/* $(BUILD)/*
+	$(RM) $(PREFIX)/raspijpgs $(ASSET_FILES) $(BUILD)/*.o
 
 .PHONY: all clean calling_from_make install


### PR DESCRIPTION
Apparently someone had $(BUILD) or $(PREFIX) unset and this turned into
an `rm -fr /`. This isn't perfect since intermediate directories aren't
removed, but it's much more specific than before and will hopefully
avoid a bad accident in the future.